### PR TITLE
Add `MustGet` function

### DIFF
--- a/internal/test/nullable_test.go
+++ b/internal/test/nullable_test.go
@@ -26,6 +26,7 @@ func TestNullable(t *testing.T) {
 	value, err := myObj.Foo.Get()
 	require.NoError(t, err)
 	require.Equal(t, "bar", value)
+	require.Equal(t, "bar", myObj.Foo.MustGet())
 	// serialize back to json: leads to the same data
 	require.Equal(t, data, serialize(myObj, t))
 
@@ -50,6 +51,7 @@ func TestNullable(t *testing.T) {
 	require.True(t, myObj.Foo.IsSpecified())
 	_, err = myObj.Foo.Get()
 	require.ErrorContains(t, err, "value is null")
+	require.Panics(t, func() { myObj.Foo.MustGet() })
 	// serialize back to json: leads to the same data
 	require.Equal(t, data, serialize(myObj, t))
 

--- a/nullable.go
+++ b/nullable.go
@@ -51,6 +51,15 @@ func (t Nullable[T]) Get() (T, error) {
 	return t[true], nil
 }
 
+// MustGet retrieves the underlying value, if present, and panics if the value was not present
+func (t Nullable[T]) MustGet() T {
+	v, err := t.Get()
+	if err != nil {
+		panic(err)
+	}
+	return v
+}
+
 // Set sets the underlying value to a given value
 func (t *Nullable[T]) Set(value T) {
 	*t = map[bool]T{true: value}

--- a/nullable_example_test.go
+++ b/nullable_example_test.go
@@ -252,6 +252,7 @@ func ExampleNullable_unmarshalRequired() {
 		return
 	}
 	fmt.Printf("obj.Name.Get(): %#v <nil>\n", val)
+	fmt.Printf("obj.Name.MustGet(): %#v\n", obj.Name.MustGet())
 	fmt.Println("---")
 
 	// when it's set explicitly to a specific value
@@ -274,6 +275,7 @@ func ExampleNullable_unmarshalRequired() {
 		return
 	}
 	fmt.Printf("obj.Name.Get(): %#v <nil>\n", val)
+	fmt.Printf("obj.Name.MustGet(): %#v\n", obj.Name.MustGet())
 	fmt.Println("---")
 
 	// Output:
@@ -289,11 +291,13 @@ func ExampleNullable_unmarshalRequired() {
 	// obj.Name.IsSpecified(): true
 	// obj.Name.IsNull(): false
 	// obj.Name.Get(): "" <nil>
+	// obj.Name.MustGet(): ""
 	// ---
 	// Value:
 	// obj.Name.IsSpecified(): true
 	// obj.Name.IsNull(): false
 	// obj.Name.Get(): "foo" <nil>
+	// obj.Name.MustGet(): "foo"
 	// ---
 }
 
@@ -351,6 +355,7 @@ func ExampleNullable_unmarshalOptional() {
 		return
 	}
 	fmt.Printf("obj.Name.Get(): %#v <nil>\n", val)
+	fmt.Printf("obj.Name.MustGet(): %#v\n", obj.Name.MustGet())
 	fmt.Println("---")
 
 	// when it's set explicitly to a specific value
@@ -373,6 +378,7 @@ func ExampleNullable_unmarshalOptional() {
 		return
 	}
 	fmt.Printf("obj.Name.Get(): %#v <nil>\n", val)
+	fmt.Printf("obj.Name.MustGet(): %#v\n", obj.Name.MustGet())
 	fmt.Println("---")
 
 	// Output:
@@ -388,10 +394,12 @@ func ExampleNullable_unmarshalOptional() {
 	// obj.Name.IsSpecified(): true
 	// obj.Name.IsNull(): false
 	// obj.Name.Get(): "" <nil>
+	// obj.Name.MustGet(): ""
 	// ---
 	// Value:
 	// obj.Name.IsSpecified(): true
 	// obj.Name.IsNull(): false
 	// obj.Name.Get(): "foo" <nil>
+	// obj.Name.MustGet(): "foo"
 	// ---
 }


### PR DESCRIPTION
## Reason
1. Many cases will do` IsSpecified()` and `isNull()` judgment before calling `Get()`.

2. Compared to `val, _ := foo.Get()`, `foo.MustGet()` in many scenarios will be more atomic, the call logic does not have to truncate or be separated from other logic (such as assigning a value to another struct).

## Test
```sh
=== RUN   ExampleNewNullNullable
--- PASS: ExampleNewNullNullable (0.00s)
=== RUN   ExampleNewNullableWithValue
--- PASS: ExampleNewNullableWithValue (0.00s)
=== RUN   ExampleNullable_marshalRequired
--- PASS: ExampleNullable_marshalRequired (0.00s)
=== RUN   ExampleNullable_marshalOptional
--- PASS: ExampleNullable_marshalOptional (0.00s)
=== RUN   ExampleNullable_unmarshalRequired
--- PASS: ExampleNullable_unmarshalRequired (0.00s)
=== RUN   ExampleNullable_unmarshalOptional
--- PASS: ExampleNullable_unmarshalOptional (0.00s)
PASS

=== RUN   TestNullable
--- PASS: TestNullable (0.00s)
PASS
```