### PR TITLE
feat: new method for fetching ignoring error

### DIFF
--- a/nullable.go
+++ b/nullable.go
@@ -51,7 +51,15 @@ func (t Nullable[T]) Get() (T, error) {
 	return t[true], nil
 }
 
-// MustGet retrieves the underlying value, if present, and panics if the value was not present
+// Dig retrieves the underlying value or returns empty value if not present or was `null`. Use Get to distinguish between these cases.
+func (t Nullable[T]) GetOrEmpty() T {
+	var empty T
+	if !t.IsSpecified() || t.IsNull() {
+		return empty
+	}
+	return t[true]
+}
+
 func (t Nullable[T]) MustGet() T {
 	v, err := t.Get()
 	if err != nil {

--- a/nullable_example_test.go
+++ b/nullable_example_test.go
@@ -252,6 +252,7 @@ func ExampleNullable_unmarshalRequired() {
 		return
 	}
 	fmt.Printf("obj.Name.Get(): %#v <nil>\n", val)
+	fmt.Printf("obj.Name.GetOrEmpty(): %#v\n", obj.Name.GetOrEmpty())
 	fmt.Printf("obj.Name.MustGet(): %#v\n", obj.Name.MustGet())
 	fmt.Println("---")
 
@@ -275,6 +276,7 @@ func ExampleNullable_unmarshalRequired() {
 		return
 	}
 	fmt.Printf("obj.Name.Get(): %#v <nil>\n", val)
+	fmt.Printf("obj.Name.GetOrEmpty(): %#v\n", obj.Name.GetOrEmpty())
 	fmt.Printf("obj.Name.MustGet(): %#v\n", obj.Name.MustGet())
 	fmt.Println("---")
 
@@ -291,12 +293,14 @@ func ExampleNullable_unmarshalRequired() {
 	// obj.Name.IsSpecified(): true
 	// obj.Name.IsNull(): false
 	// obj.Name.Get(): "" <nil>
+	// obj.Name.GetOrEmpty(): ""
 	// obj.Name.MustGet(): ""
 	// ---
 	// Value:
 	// obj.Name.IsSpecified(): true
 	// obj.Name.IsNull(): false
 	// obj.Name.Get(): "foo" <nil>
+	// obj.Name.GetOrEmpty(): "foo"
 	// obj.Name.MustGet(): "foo"
 	// ---
 }
@@ -355,6 +359,7 @@ func ExampleNullable_unmarshalOptional() {
 		return
 	}
 	fmt.Printf("obj.Name.Get(): %#v <nil>\n", val)
+	fmt.Printf("obj.Name.GetOrEmpty(): %#v\n", obj.Name.GetOrEmpty())
 	fmt.Printf("obj.Name.MustGet(): %#v\n", obj.Name.MustGet())
 	fmt.Println("---")
 
@@ -378,6 +383,7 @@ func ExampleNullable_unmarshalOptional() {
 		return
 	}
 	fmt.Printf("obj.Name.Get(): %#v <nil>\n", val)
+	fmt.Printf("obj.Name.GetOrEmpty(): %#v\n", obj.Name.GetOrEmpty())
 	fmt.Printf("obj.Name.MustGet(): %#v\n", obj.Name.MustGet())
 	fmt.Println("---")
 
@@ -394,12 +400,14 @@ func ExampleNullable_unmarshalOptional() {
 	// obj.Name.IsSpecified(): true
 	// obj.Name.IsNull(): false
 	// obj.Name.Get(): "" <nil>
+	// obj.Name.GetOrEmpty(): ""
 	// obj.Name.MustGet(): ""
 	// ---
 	// Value:
 	// obj.Name.IsSpecified(): true
 	// obj.Name.IsNull(): false
 	// obj.Name.Get(): "foo" <nil>
+	// obj.Name.GetOrEmpty(): "foo"
 	// obj.Name.MustGet(): "foo"
 	// ---
 }


### PR DESCRIPTION
This may sound crazy, but I am working on a codebase where we use OpenAPI schema to describe a (YAML) document. All fields (except document name) are optional so I have to work with many optional fiels. While I want to explore the new feature `omitzero`, I am evaluating `nullable` to do the heavylifting and I am not even sure if this is gonna work yet.

But I would love to have a method - workting title - `Dig` that does exactly what `Get` does but ignores the error and returns an empty value. Assuming that all fields within structs are also treated with `nullable` my theory is this can simulate behavior of `omitzero`.

```go
a := value.Field.Dig().Field.Dig()
```

Am I crazy? I think I am. Well, let’s hear from others. I am unsure about the name for such method, but I want something that is short so I came up with `Dig` which is probably too wild. But `GetWithoutError` would not work that is way too long. Also this does not have tests yet because I am unsure if you like this or if there are not flaws in my idea.